### PR TITLE
Fix NoMethodError on unparseable API response

### DIFF
--- a/lib/mailpace-rails.rb
+++ b/lib/mailpace-rails.rb
@@ -63,12 +63,12 @@ module Mailpace
     end
 
     def handle_response(result)
-      return result unless result.code != 200
+      return result if result.code == 200
 
       parsed_response = result.parsed_response
       error_message = join_error_messages(parsed_response)
 
-      raise DeliveryError, "MAILPACE Error: #{error_message}" unless error_message.empty?
+      raise DeliveryError, "MAILPACE Error: #{error_message.presence || "HTTP #{result.code}"}"
     end
 
     def format_attachments(attachments)
@@ -93,7 +93,8 @@ module Mailpace
     end
 
     def join_error_messages(response)
-      # Join 'error' and 'errors' keys from response into a single string
+      return '' unless response.is_a?(Hash)
+
       [response['error'], response['errors']].compact.join(', ')
     end
   end


### PR DESCRIPTION
## Summary
- Guard `join_error_messages` against nil/non-Hash `parsed_response`
- Always raise `DeliveryError` on non-200 responses, with HTTP status code fallback when body is unparseable

## Context
Rollbar #3254 — Mailpace API returned a non-200 response with a nil `parsed_response`, causing `NoMethodError: undefined method '[]' for nil` in `join_error_messages`.