### PR TITLE
Forward Idempotency-Key header to MailPace API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ test/dummy/storage/
 test/dummy/tmp/
 *.gem
 *DS_Store
+.omx/
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.3.3
+
+- Forward the `Idempotency-Key` HTTP header to the MailPace API when a mailer sets
+  `headers['Idempotency-Key']` or `headers['idempotency_key']`. No idempotency
+  header is sent when the mailer does not set one.
+
 # 0.3.2
 
 - Support for Rails 7.0.4.1, which uses Mail 2.8 under the hood

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mailpace-rails (0.3.2)
+    mailpace-rails (0.3.3)
       actionmailbox (>= 6.0.0)
       actionmailer (>= 6.0.0)
       activestorage (>= 6.0.0)

--- a/README.md
+++ b/README.md
@@ -108,6 +108,26 @@ class TestMailer < ApplicationMailer
 end
 ```
 
+## Idempotency
+
+To prevent duplicate sends when your background job retries a mailer that already hit the MailPace API, set an `Idempotency-Key` header on the mail. MailPace will deduplicate requests with the same key for 24 hours.
+
+```ruby
+class WelcomeMailer < ApplicationMailer
+  def welcome(user)
+    headers['Idempotency-Key'] = Digest::SHA256.hexdigest(
+      [self.class.name, action_name, user.id, Time.current.to_i / 3600].join('|')
+    )
+
+    mail(to: user.email, subject: 'Welcome')
+  end
+end
+```
+
+The key must be deterministic across retries of the same logical send. A common pattern is `SHA256(mailer_class + action + recipient + record_id + hour_bucket)`.
+
+See the MailPace docs for idempotency semantics: https://docs.mailpace.com/guide/idempotency/
+
 ## ActionMailbox (for receiving inbound emails)
 
 As of v0.3.0, this Gem supports handling Inbound Emails (see https://docs.mailpace.com/guide/inbound/ for more details) via ActionMailbox. To set this up:

--- a/lib/mailpace-rails.rb
+++ b/lib/mailpace-rails.rb
@@ -37,18 +37,36 @@ module Mailpace
           attachments: format_attachments(mail.attachments),
           tags: mail.header['tags'].to_s
         }.delete_if { |_key, value| value.blank? }.to_json,
-        headers: {
-          'User-Agent' => "MailPace Rails Gem v#{Mailpace::Rails::VERSION}",
-          'Accept' => 'application/json',
-          'Content-Type' => 'application/json',
-          'Mailpace-Server-Token' => settings[:api_token]
-        }
+        headers: build_headers(mail)
       )
 
       handle_response(result)
     end
 
     private
+
+    def build_headers(mail)
+      headers = {
+        'User-Agent' => "MailPace Rails Gem v#{Mailpace::Rails::VERSION}",
+        'Accept' => 'application/json',
+        'Content-Type' => 'application/json',
+        'Mailpace-Server-Token' => settings[:api_token]
+      }
+
+      idempotency_key = extract_idempotency_key(mail)
+      headers['Idempotency-Key'] = idempotency_key if idempotency_key.present?
+
+      headers
+    end
+
+    def extract_idempotency_key(mail)
+      ['Idempotency-Key', 'idempotency_key'].each do |header_name|
+        idempotency_key = mail.header[header_name]&.to_s
+        return idempotency_key if idempotency_key.present?
+      end
+
+      nil
+    end
 
     def check_api_token(values)
       return if values[:api_token].present?

--- a/lib/mailpace-rails/version.rb
+++ b/lib/mailpace-rails/version.rb
@@ -1,5 +1,5 @@
 module Mailpace
   module Rails
-    VERSION = '0.3.2'
+    VERSION = '0.3.3'
   end
 end

--- a/test/dummy/app/mailers/idempotency_mailer.rb
+++ b/test/dummy/app/mailers/idempotency_mailer.rb
@@ -1,0 +1,18 @@
+class IdempotencyMailer < ApplicationMailer
+  default from: 'notifications@example.com',
+          to: 'fake@sdfasdfsdaf.com'
+
+  def hyphenated_key
+    headers['Idempotency-Key'] = 'hyphen-123'
+    mail(subject: 'Hello', body: 'Hi')
+  end
+
+  def snake_case_key
+    headers['idempotency_key'] = 'snake-123'
+    mail(subject: 'Hello', body: 'Hi')
+  end
+
+  def no_key
+    mail(subject: 'Hello', body: 'Hi')
+  end
+end

--- a/test/mailpace/mailer_test.rb
+++ b/test/mailpace/mailer_test.rb
@@ -45,6 +45,39 @@ class Mailpace::Rails::Test < ActiveSupport::TestCase
     @test_email.deliver!
   end
 
+  test 'forwards Idempotency-Key header when set on the mail' do
+    IdempotencyMailer.hyphenated_key.deliver!
+
+    assert_requested(
+      :post, 'https://app.mailpace.com/api/v1/send',
+      times: 1
+    ) do |req|
+      req.headers['Idempotency-Key'] == 'hyphen-123'
+    end
+  end
+
+  test 'forwards Idempotency-Key header when set with snake_case name' do
+    IdempotencyMailer.snake_case_key.deliver!
+
+    assert_requested(
+      :post, 'https://app.mailpace.com/api/v1/send',
+      times: 1
+    ) do |req|
+      req.headers['Idempotency-Key'] == 'snake-123'
+    end
+  end
+
+  test 'does not send Idempotency-Key header when mail has none' do
+    IdempotencyMailer.no_key.deliver!
+
+    assert_requested(
+      :post, 'https://app.mailpace.com/api/v1/send',
+      times: 1
+    ) do |req|
+      !req.headers.key?('Idempotency-Key')
+    end
+  end
+
   test 'supports multiple attachments' do
     t = TestMailer.welcome_email
     t.attachments['logo.png'] = File.read("#{Dir.pwd}/test/logo.png")


### PR DESCRIPTION
## Summary
- Forward a present `Idempotency-Key` from ActionMailer messages into the MailPace HTTP API request.
- Support both `headers['Idempotency-Key']` and `headers['idempotency_key']` while omitting the HTTP header when no key is set.
- Add request-level WebMock coverage for hyphenated, snake-case, and absent idempotency headers.
- Document idempotency usage and bump the gem version to `0.3.3`.

## Why
Consumers can set retry-safe idempotency headers on the in-memory `Mail::Message`, but the delivery adapter previously sent only its fixed HTTP header set to MailPace. That meant MailPace never saw the caller's key, so retry deduplication was not engaged.

## Changes
### Forward idempotency keys to MailPace API
- **What:** Replaces the inline HTTP header hash with `build_headers(mail)` and extracts an idempotency key from either the canonical hyphenated mail header or the existing snake-case variant.
- **Why:** The pinned `feature/handle-exception` branch had no idempotency forwarding, and the older `master` implementation only checked the snake-case name.

## Testing
- [x] `mise exec ruby@3.4.5 -- bundle exec rake test` passed: 25 runs, 25 assertions, 0 failures, 0 errors, 0 skips.
- [x] `git diff --check` passed.

## Risk & Rollout
- **Risk:** Low - the change only adds an optional outbound HTTP header when callers explicitly set one.
- **Rollback:** Revert this commit to return to the previous fixed header set.
- **Monitoring:** After updating consumers, inspect MailPace sends for recorded idempotency keys on retried mailer paths.