### PR TITLE
Expose structured Mailpace delivery failure metadata

### DIFF
--- a/lib/mailpace-rails.rb
+++ b/lib/mailpace-rails.rb
@@ -90,10 +90,17 @@ module Mailpace
     def handle_response(result)
       return result if result.code == 200
 
-      parsed_response = result.parsed_response
+      status_code = result.code.to_i
+      parsed_response = parsed_response_metadata(result.parsed_response)
       error_message = join_error_messages(parsed_response)
+      provider_error = error_message.presence
 
-      raise DeliveryError, "MAILPACE Error: #{error_message.presence || "HTTP #{result.code}"}"
+      raise DeliveryError.new(
+        "MAILPACE Error: #{provider_error || "HTTP #{status_code}"}",
+        status_code: status_code,
+        provider_error: provider_error,
+        parsed_response: parsed_response
+      )
     end
 
     def format_attachments(attachments)
@@ -122,10 +129,45 @@ module Mailpace
 
       [response['error'], response['errors']].compact.join(', ')
     end
+
+    def parsed_response_metadata(response)
+      response if response.is_a?(Hash)
+    end
   end
 
   class Error < StandardError; end
-  class DeliveryError < StandardError; end
+  class DeliveryError < StandardError
+    attr_reader :status_code, :provider_error, :parsed_response
+
+    def initialize(message = nil, status_code: nil, provider_error: nil, parsed_response: nil)
+      super(message)
+      @status_code = status_code
+      @provider_error = provider_error
+      @parsed_response = parsed_response
+    end
+
+    def concurrency_rejection?
+      status_code == 409 || error_text.include?('Concurrent requests detected')
+    end
+
+    def server_error?
+      status_code.to_i >= 500 && status_code.to_i < 600
+    end
+
+    def client_error?
+      status_code.to_i >= 400 && status_code.to_i < 500
+    end
+
+    def blocked_address?
+      error_text.include?('contains a blocked address')
+    end
+
+    private
+
+    def error_text
+      provider_error.presence || message.to_s
+    end
+  end
 
   def self.root
     Pathname.new(File.expand_path(File.join(__dir__, '..')))

--- a/test/mailpace/mailer_test.rb
+++ b/test/mailpace/mailer_test.rb
@@ -230,9 +230,92 @@ class Mailpace::Rails::Test < ActiveSupport::TestCase
 
     t = TestMailer.welcome_email
 
-    assert_raise(Mailpace::DeliveryError, 'MAILPACE Error: contains a blocked address') do
+    error = assert_raise(Mailpace::DeliveryError) do
       t.deliver!
     end
+
+    assert_equal 'MAILPACE Error: contains a blocked address', error.message
+    assert_equal 400, error.status_code
+    assert_equal 'contains a blocked address', error.provider_error
+    assert_equal({ 'error' => 'contains a blocked address' }, error.parsed_response)
+    assert error.client_error?
+    assert error.blocked_address?
+    refute error.server_error?
+  end
+
+  test 'DeliveryError keeps normal exception construction compatibility' do
+    assert_instance_of Mailpace::DeliveryError, Mailpace::DeliveryError.new
+
+    assert_raise(Mailpace::DeliveryError) do
+      raise Mailpace::DeliveryError
+    end
+  end
+
+  test 'DeliveryError predicates fall back to existing message text' do
+    error = Mailpace::DeliveryError.new('MAILPACE Error: contains a blocked address')
+
+    assert error.blocked_address?
+  end
+
+  test 'DeliveryError exposes response metadata for provider concurrency errors' do
+    stub_request(:post, 'https://app.mailpace.com/api/v1/send')
+      .to_return(
+        body: { error: 'Concurrent requests detected' }.to_json,
+        headers: { content_type: 'application/json' },
+        status: 409
+      )
+
+    error = assert_raise(Mailpace::DeliveryError) do
+      TestMailer.welcome_email.deliver!
+    end
+
+    assert_equal 'MAILPACE Error: Concurrent requests detected', error.message
+    assert_equal 409, error.status_code
+    assert_equal 'Concurrent requests detected', error.provider_error
+    assert_equal({ 'error' => 'Concurrent requests detected' }, error.parsed_response)
+    assert error.concurrency_rejection?
+    assert error.client_error?
+    refute error.server_error?
+  end
+
+  test 'DeliveryError provider_error can come from errors response key' do
+    stub_request(:post, 'https://app.mailpace.com/api/v1/send')
+      .to_return(
+        body: { errors: ['first failure', 'second failure'] }.to_json,
+        headers: { content_type: 'application/json' },
+        status: 403
+      )
+
+    error = assert_raise(Mailpace::DeliveryError) do
+      TestMailer.welcome_email.deliver!
+    end
+
+    assert_equal 'MAILPACE Error: first failure, second failure', error.message
+    assert_equal 403, error.status_code
+    assert_equal 'first failure, second failure', error.provider_error
+    assert_equal({ 'errors' => ['first failure', 'second failure'] }, error.parsed_response)
+    assert error.client_error?
+  end
+
+  test 'DeliveryError falls back to HTTP status for non-json responses' do
+    stub_request(:post, 'https://app.mailpace.com/api/v1/send')
+      .to_return(
+        body: 'Gateway timeout with raw provider details',
+        headers: { content_type: 'text/plain' },
+        status: 504
+      )
+
+    error = assert_raise(Mailpace::DeliveryError) do
+      TestMailer.welcome_email.deliver!
+    end
+
+    assert_equal 'MAILPACE Error: HTTP 504', error.message
+    assert_equal 504, error.status_code
+    assert_nil error.provider_error
+    assert_nil error.parsed_response
+    assert error.server_error?
+    refute error.client_error?
+    refute_respond_to error, :raw_response
   end
 
   test 'supports in-reply-to' do


### PR DESCRIPTION
## Summary
- Adds structured metadata to Mailpace::DeliveryError for non-200 delivery responses.
- Preserves the existing exception class and human-readable message shape.
- Adds helper predicates for concurrency rejections, client errors, server errors, and blocked-address responses.
- Avoids exposing the raw HTTParty response object on production exceptions.

## Why
Suppli currently has to classify Mailpace delivery failures by parsing DeliveryError#message text. Structured status and provider-error metadata lets consumers distinguish 409 concurrency rejections, 5xx gateway/provider failures, and blocked-address responses without brittle string parsing.

## Changes
### Expose structured Mailpace delivery failure metadata
- What: DeliveryError now carries status_code, provider_error, and Hash-only parsed_response metadata, plus classification helpers.
- What: handle_response still raises Mailpace::DeliveryError and preserves fallback messages like MAILPACE Error: HTTP 504 for non-JSON responses.
- What: Tests cover blocked-address errors, concurrency errors, errors-key payloads, non-JSON 504 fallbacks, predicate message fallback, and no-arg exception construction.
- Why: Keep current rescue/message behavior stable while giving consumers safer classification fields.

## Testing
- RAILS_TEST_VERSION=7.2.1 BUNDLE_GEMFILE=/tmp/mailpace-rails-bundle/Gemfile mise exec ruby@3.4.5 -- bundle exec rake test
- Result: 38 runs, 68 assertions, 0 failures, 0 errors, 0 skips
- git diff --check
- ruby -c lib/mailpace-rails.rb
- ruby -c test/mailpace/mailer_test.rb

## Risk & Rollout
- Risk: Low. The change is limited to non-200 response exception metadata and preserves the existing DeliveryError class and message shape.
- Rollback: Revert this single commit.
- Monitoring: Watch Mailpace delivery Rollbar entries for stable message titles and confirm consumers can classify status_code without message parsing.

## Notes
- No raw_response accessor is included to avoid attaching raw provider body content to exception-reporting surfaces.
- This targets the fork release line on stable and keeps the existing idempotency-header behavior intact.